### PR TITLE
Add support for KVM flag (Managed Identity)

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ OPTIONS:
    --azure-key-vault-client-secret value, --kvs value  This is the client secret used to authenticate to Azure, which will be used to generate an access token. This parameter is not required if an access token is supplied directly with the '--azure-key-vault-accesstoken' option. If this parameter is supplied, '--azure-key-vault-client-id' must be supplied as well. [$DUCTTAPE_SIGN_AZ_KEY_VAULT_CLIENT_SECRET]
    --azure-key-vault-certificate value, --kvc value    The name of the certificate used to perform the signing operation. [$DUCTTAPE_SIGN_AZ_KEY_VAULT_CERT]
    --azure-key-vault-accesstoken value, --kva value    An access token used to authenticate to Azure. This can be used instead of the '--azure-key-vault-client-id' and '--azure-key-vault-client-secret' options. This is useful if AzureSignTool is being used as part of another program that is already authenticated and has an access token to Azure. [$DUCTTAPE_SIGN_AZ_KEY_VAULT_ACCESS_TOKEN]
+   --azure-key-vault-managed-identity, --kvm           Use managed identity to authenticate to Azure. This can be used instead of the '--azure-key-vault-client-id' or '--azure-key-vault-accesstoken' options.
    -h, -?                                              show help (default: false)
 
 ```

--- a/main.go
+++ b/main.go
@@ -187,7 +187,7 @@ func main() {
 					&cli.BoolFlag{
 						Name:    "azure-key-vault-managed-identity",
 						Aliases: []string{"kvm"},
-						Usage:   "Use managed identity to authenticate to Azure. This can be used instead of the '--azure-key-vault-client-id' or '--azure-key-vault-accesstoken' options.",
+						Usage:   "Use managed identity to authenticate to Azure. This can be used instead of the '--azure-key-vault-client-id' or '--azure-key-vault-accesstoken' options. Requires a build of AzureSignTool from at least commit [vcsjones/AzureSignTool@0282752]",
 						EnvVars: []string{"DUCTTAPE_SIGN_AZ_KEY_VAULT_MANAGED_IDENTITY"},
 					},
 				},

--- a/main.go
+++ b/main.go
@@ -184,6 +184,12 @@ func main() {
 						Usage:    "An access token used to authenticate to Azure. This can be used instead of the '--azure-key-vault-client-id' and '--azure-key-vault-client-secret' options. This is useful if AzureSignTool is being used as part of another program that is already authenticated and has an access token to Azure.",
 						EnvVars:  []string{"DUCTTAPE_SIGN_AZ_KEY_VAULT_ACCESS_TOKEN"},
 					},
+					&cli.BoolFlag{
+						Name:    "azure-key-vault-managed-identity",
+						Aliases: []string{"kvm"},
+						Usage:   "Use managed identity to authenticate to Azure. This can be used instead of the '--azure-key-vault-client-id' or '--azure-key-vault-accesstoken' options.",
+						EnvVars: []string{"DUCTTAPE_SIGN_AZ_KEY_VAULT_MANAGED_IDENTITY"},
+					},
 				},
 				Action: func(c *cli.Context) error {
 					var err error
@@ -235,6 +241,9 @@ func main() {
 					args = appendIfSet(c, args, "kvi")
 					args = appendIfSet(c, args, "kva")
 					args = appendIfSet(c, args, "kvs")
+					if c.Bool("kvm") {
+						args = append(args, "-kvm")
+					}
 					args = appendIfSet(c, args, "d")
 
 					if c.IsSet("tr") {


### PR DESCRIPTION
Sets the KVM flag (Azure Managed Identity) if the following environment variable is set:
DUCTTAPE_SIGN_AZ_KEY_VAULT_MANAGED_IDENTITY=true