### PR TITLE
Ignore -as option to SignTool

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ USAGE:
 
 OPTIONS:
    -a                                                  Select the best signing cert automatically. Note: ignored by this tool. (default: false)
+   -as                                                 Append signature. Note: ignored by this tool. (default: false)
    --sha1 value                                        Specify the SHA1 thumbprint of the signing cert. [$DUCTTAPE_SIGN_SHA1]
    --fd value                                          Specifies the file digest algorithm to use for creating file signatures. (default: "SHA1") [$DUCTTAPE_SIGN_FILE_DIGEST]
    -s value                                            Specify the Store to open when searching for the cert. (default: "MY") [$DUCTTAPE_SIGN_STORE]

--- a/main.go
+++ b/main.go
@@ -105,6 +105,10 @@ func main() {
 						Name:  "a",
 						Usage: "Select the best signing cert automatically. Note: ignored by this tool.",
 					},
+					&cli.BoolFlag{
+						Name:  "as",
+						Usage: "Append signature. Note: ignored by this tool.",
+					},
 					&cli.StringFlag{
 						Name:     "sha1",
 						Usage:    "Specify the SHA1 thumbprint of the signing cert.",


### PR DESCRIPTION
AdvancedInstaller 7.2 added the -as (append signature) parameter when calling SignTool, even though we are only signing with one certificate.

I did have a quick look in Advanced Installer to see if I could prevent this, but did not find anything.